### PR TITLE
More fixes for our use-case of this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ authorized_keys file used will default to /home/bob/.ssh/authorized_keys, where 
 
     plugin.sshkey.server.authorized_keys = /etc/mcollective/my_other_authorized_keys
 
+As in sshd_config(5)'s AuthorizedKeysFile property, the %u sequence will be replaced with the user ID of
+the user calling the agent, e.g.
+
+    plugin.sshkey.server.authorized_keys = /etc/admin_authorized_keys/%u
+
 ###send_key
 
 This will send the specified public key as part of the reply to the client. This is useful when you do not want to manage

--- a/security/sshkey.rb
+++ b/security/sshkey.rb
@@ -341,6 +341,7 @@ module MCollective
           end
 
         elsif (authorized_keys = lookup_config_option('authorized_keys'))
+          authorized_keys = authorized_keys.sub('%u') { |c| user }
           Log.debug("Found custom authorized_keys file: '%s'" % authorized_keys)
           verifier.authorized_keys_file = authorized_keys
 

--- a/spec/security/sshkey_spec.rb
+++ b/spec/security/sshkey_spec.rb
@@ -581,6 +581,14 @@ module MCollective
           @plugin.send(:node_verifier, 'caller=rspec', nil, nil).should == node_verifier
         end
 
+        it 'should return a verifier having interpolcated %u into authorized_keys file path' do
+          @plugin.stubs(:lookup_config_option).with('publickey_dir').returns(false)
+          @plugin.stubs(:lookup_config_option).with('authorized_keys').returns('ssh/%u/authorized_keys')
+          node_verifier.expects(:authorized_keys_file=).with('ssh/rspec/authorized_keys')
+          node_verifier.expects(:use_agent=).with(false)
+          @plugin.send(:node_verifier, 'caller=rspec', nil, nil).should == node_verifier
+        end
+
         it 'should return a verifier with a public key loaded directly from disk' do
           @plugin.stubs(:lookup_config_option).with('publickey_dir').returns('ssh/authorized_keys')
           File.expects(:directory?).with('ssh/authorized_keys').returns(true)


### PR DESCRIPTION
ssh-agent not being disabled by the mcollective daemon made things look like they were working (with 1 node), but they weren't - I've turned this off universally (in the server side verifier) as using the user's agent in the server is just bad news.

Subsequent to this, I needed to change the config to our custom authorized_keys path, which isn't /home/%u/.ssh/authorized_keys - so I made %u interpolate in the same way you can use it in an ssh config.
