### PR TITLE
Fixed bug in find_key_in_known_hosts

### DIFF
--- a/security/sshkey.rb
+++ b/security/sshkey.rb
@@ -240,13 +240,14 @@ module MCollective
       # Looks for a specific key in a known hosts file
       def find_key_in_known_hosts(hostname, known_hosts)
         key = nil
-        search_for = /^#{hostname}/
+        #search_for = /^#{hostname}/
 
         if File.exists?(known_hosts)
           File.read(known_hosts).each_line do |line|
             fields = line.split
             fields[0].split(',').each do |maybehost|
-              if maybehost =~ search_for
+              #if maybehost =~ search_for
+              if maybehost == hostname
                 fields = line.split
                 key = fields[-2] << ' ' << fields[-1]
                 break


### PR DESCRIPTION
This patch fixes a bug where the incorrect key is found if you have one (or more) hostnames which themselves include the names of other hosts, e.g.: host1, host11, host111, ... hostA, hostAA, ...