### PR TITLE
don't use Etc.getlogin

### DIFF
--- a/security/sshkey.rb
+++ b/security/sshkey.rb
@@ -99,7 +99,7 @@ module MCollective
       end
 
       def callerid
-        'sshkey=%s' % Etc.getlogin
+        'sshkey=%s' % Etc.getpwuid(Process.uid).name
       end
 
       private
@@ -284,7 +284,7 @@ module MCollective
 
         else
           begin
-            user = Etc.getlogin
+            user = Etc.getpwuid(Process.uid).name
             known_hosts = File.join(Etc.getpwnam(user).dir, '.ssh', 'known_hosts')
             Log.debug("Using default known_hosts file for user '%s': ''" % [user, known_hosts])
             verifier.add_public_key_data(find_key_in_known_hosts(senderid, "%s" % known_hosts))

--- a/spec/security/sshkey_spec.rb
+++ b/spec/security/sshkey_spec.rb
@@ -208,7 +208,9 @@ module MCollective
 
       describe '#callerid' do
         it 'should return the callerid in the correct format' do
-          Etc.stubs(:getlogin).returns('rspec')
+          passwd = mock('passwd')
+          passwd.stubs(:name).returns('rspec')
+          Etc.stubs(:getpwuid).returns(passwd)
           @plugin.callerid.should == 'sshkey=rspec'
         end
       end
@@ -484,7 +486,9 @@ module MCollective
 
         before do
           SSH::Key::Verifier.stubs(:new).with('host1.your.com').returns(client_verifier)
-          Etc.stubs(:getlogin).returns('rspec')
+          passwd = mock('passwd')
+          passwd.stubs(:name).returns('rspec')
+          Etc.stubs(:getpwuid).returns(passwd)
           client_verifier.stubs(:use_agent=).with(false)
           client_verifier.stubs(:use_authorized_keys=).with(false)
         end


### PR DESCRIPTION
I discovered that `mco` would become confused when called after a `su` or via Jenkins.

additionally, RDoc states: ["Returns the short user name of the currently logged in user. Unfortunately, it is often rather easy to fool getlogin(). Avoid getlogin() for security-related purposes."](http://ruby-doc.org/stdlib-1.9.3/libdoc/etc/rdoc/Etc.html#method-c-getlogin)

replacement code taken from https://github.com/embarkmobile/foreman_god/issues/1
