### PR TITLE
Add additional flexibility to handling ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ By default clients using the sshkey security plugin will use ssh-agent to sign a
 using the sender's public key found in its __known_hosts__ file. However just like servers, clients can be configured to change this default
 behavior.
 
-Clients will by default use the username of the unix user which is logged in, but this can be overridden using the MCOLLECTIVE_CALLERID environment
+Clients will by default use the username of the unix user which is logged in, but this can be overridden using the MCOLLECTIVE_SSH_CALLERID environment
 variable.
 
 ###private_key

--- a/security/sshkey.rb
+++ b/security/sshkey.rb
@@ -99,7 +99,7 @@ module MCollective
       end
 
       def callerid
-        'sshkey=%s' % (ENV['MCOLLECTIVE_CALLERID'] ? ENV['MCOLLECTIVE_CALLERID'] : Etc.getpwuid(Process.uid).name)
+        'sshkey=%s' % (ENV['MCOLLECTIVE_SSH_CALLERID'] ? ENV['MCOLLECTIVE_SSH_CALLERID'] : Etc.getpwuid(Process.uid).name)
       end
 
       private

--- a/spec/security/sshkey_spec.rb
+++ b/spec/security/sshkey_spec.rb
@@ -22,7 +22,7 @@ module MCollective
 
     describe Sshkey do
       before do
-        ENV['MCOLLECTIVE_CALLERID'] = nil # Make sure to blank these before tests
+        ENV['MCOLLECTIVE_SSH_CALLERID'] = nil # Make sure to blank these before tests
         ENV['MCOLLECTIVE_SSH_KEY'] = nil
         ENV['MCOLLECTIVE_SSH_KEY_PASSPHRASE'] = nil
 
@@ -221,7 +221,7 @@ module MCollective
         end
         context 'with environment variable' do
           it 'should return the callerid in the correct format' do
-            ENV['MCOLLECTIVE_CALLERID'] = 'rspec2'
+            ENV['MCOLLECTIVE_SSH_CALLERID'] = 'rspec2'
             @plugin.callerid.should == 'sshkey=rspec2'
           end
         end


### PR DESCRIPTION
The ssh key used by clients and the client identify can now be supplied
as environment variables.

ssh keys with pass phrases are also now supported, the pass phrase
can be supplied by an environment variable or through the config file.
